### PR TITLE
Adjust loading of orientation mask.

### DIFF
--- a/src/S2/S2.php
+++ b/src/S2/S2.php
@@ -49,7 +49,7 @@ class S2 {
     }
 
     /** Mapping Hilbert traversal order to orientation adjustment mask. */
-    public static $POS_TO_ORIENTATION = array(
+    private static $POS_TO_ORIENTATION = array(
         S2CellId::SWAP_MASK,
         0,
         0,

--- a/src/S2/S2.php
+++ b/src/S2/S2.php
@@ -49,7 +49,12 @@ class S2 {
     }
 
     /** Mapping Hilbert traversal order to orientation adjustment mask. */
-    public static $POS_TO_ORIENTATION = null;
+    public static $POS_TO_ORIENTATION = array(
+        S2CellId::SWAP_MASK,
+        0,
+        0,
+        S2CellId::INVERT_MASK + S2CellId::SWAP_MASK
+    );
 
     /**
      * Returns an XOR bit mask indicating how the orientation of a child subcell
@@ -57,15 +62,14 @@ class S2 {
      * be XOR'd with the parent cell's orientation to give the orientation of
      * the child cell.
      *
-     * @param the $position
-     * @throws Exception
-     * @internal param \the $position position of the subcell in the Hilbert traversal, in
-     *     the range [0,3].
-     * @return a bit mask containing some combination of {@link #SWAP_MASK} and
-     *     {@link #INVERT_MASK}.
+     * @param int $position position of the subcell in the Hilber traversal,
+     *                      in the range [0,3].
+     * @return int a bit mask containing some combination of {@link #SWAP_MASK}
+     *             and {@link #INVERT_MASK}.
+     * @throws \Exception
      */
     public static function posToOrientation($position) {
-        if (!(0 <= $position && $position < 4)) throw new Exception();
+        if (!(0 <= $position && $position < 4)) throw new \Exception();
         return self::$POS_TO_ORIENTATION[$position];
     }
 
@@ -83,15 +87,15 @@ class S2 {
      * curve traversal with the given orientation. This is the inverse of
      * {@link #ijToPos}.
      *
-     * @param orientation the subcell orientation, in the range [0,3].
-     * @param position the position of the subcell in the Hilbert traversal, in
-     *     the range [0,3].
-     * @return the IJ-index where {@code 0->(0,0), 1->(0,1), 2->(1,0), 3->(1,1)}.
-     * @throws IllegalArgumentException if either parameter is out of bounds.
+     * @param int $orientation subcell orientation, in the range [0,3].
+     * @param int $position position of the subcell in the Hilbert traversal,
+     *                      in the range [0,3].
+     * @return int IJ-index where
+     * @throws \Exception
      */
     public static function posToIJ($orientation, $position) {
-        if (!(0 <= $orientation && $orientation <= 3)) throw new Exception();
-        if (!(0 <= $position && $position <= 3)) throw new Exception();
+        if (!(0 <= $orientation && $orientation <= 3)) throw new \Exception();
+        if (!(0 <= $position && $position <= 3)) throw new \Exception();
         return self::$POS_TO_IJ[$orientation][$position];
     }
 
@@ -779,5 +783,3 @@ class Metric {
         return $level;
     }
 }
-
-S2::$POS_TO_ORIENTATION = array(S2CellId::SWAP_MASK, 0, 0, S2CellId::INVERT_MASK + S2CellId::SWAP_MASK);


### PR DESCRIPTION
During my testing, sometimes the calls to S2::posToOrientation() would operate on NULL, and not have the mask accessible. I have no idea why that happens, but moving this array definition directly to the variable fixed that. 
